### PR TITLE
Add TTS handler and backend client

### DIFF
--- a/internal/api/tts_handler.go
+++ b/internal/api/tts_handler.go
@@ -1,0 +1,169 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"fish-speech-go/internal/backend"
+	"fish-speech-go/internal/streaming"
+)
+
+const (
+	maxRequestBodyBytes  int64 = 1 << 20 // 1 MiB
+	maxTextLength              = 2048
+	maxReferenceIDLength       = 128
+	defaultAudioFormat         = "wav"
+)
+
+type ttsRequest struct {
+	Text        string   `json:"text"`
+	ReferenceID string   `json:"reference_id"`
+	Streaming   bool     `json:"streaming"`
+	Format      string   `json:"format"`
+	TopP        *float64 `json:"top_p,omitempty"`
+	Temperature *float64 `json:"temperature,omitempty"`
+}
+
+type ttsBackend interface {
+	StreamTTS(ctx context.Context, payload backend.TTSRequest) (*http.Response, error)
+}
+
+// TTSHandler handles /v1/tts requests by validating input and streaming responses from the backend.
+type TTSHandler struct {
+	chunker *streaming.Chunker
+	backend ttsBackend
+}
+
+// NewTTSHandler constructs a new handler guarded by the provided chunker and backed by the backend client.
+func NewTTSHandler(chunker *streaming.Chunker, backend ttsBackend) *TTSHandler {
+	return &TTSHandler{chunker: chunker, backend: backend}
+}
+
+// ServeHTTP validates the request and proxies it to the backend using the chunker's Stream guard.
+func (h *TTSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	payload, err := h.parseRequest(w, r)
+	if err != nil {
+		return
+	}
+
+	backendReq := backend.TTSRequest{
+		Text:        payload.Text,
+		ReferenceID: payload.ReferenceID,
+		Streaming:   payload.Streaming,
+		Format:      payload.Format,
+		TopP:        payload.TopP,
+		Temperature: payload.Temperature,
+	}
+
+	streamErr := h.chunker.Stream(r.Context(), func(ctx context.Context) error {
+		resp, err := h.backend.StreamTTS(ctx, backendReq)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		if ct := resp.Header.Get("Content-Type"); ct != "" {
+			w.Header().Set("Content-Type", ct)
+		}
+		w.WriteHeader(resp.StatusCode)
+		_, copyErr := io.Copy(w, resp.Body)
+		return copyErr
+	})
+
+	if streamErr == nil {
+		return
+	}
+
+	h.handleStreamError(w, streamErr)
+}
+
+func (h *TTSHandler) parseRequest(w http.ResponseWriter, r *http.Request) (ttsRequest, error) {
+	var payload ttsRequest
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+
+	if err := decoder.Decode(&payload); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			h.writeError(w, http.StatusRequestEntityTooLarge, "request_too_large", "request body exceeds limit")
+			return ttsRequest{}, err
+		}
+		h.writeError(w, http.StatusBadRequest, "invalid_request", "failed to decode request payload")
+		return ttsRequest{}, err
+	}
+
+	if strings.TrimSpace(payload.Text) == "" {
+		h.writeError(w, http.StatusBadRequest, "invalid_request", "text is required")
+		return ttsRequest{}, fmt.Errorf("text missing")
+	}
+	payload.Text = strings.TrimSpace(payload.Text)
+	if len(payload.Text) > maxTextLength {
+		h.writeError(w, http.StatusBadRequest, "limit_exceeded", fmt.Sprintf("text exceeds max length of %d", maxTextLength))
+		return ttsRequest{}, fmt.Errorf("text too long")
+	}
+
+	payload.ReferenceID = strings.TrimSpace(payload.ReferenceID)
+	if len(payload.ReferenceID) > maxReferenceIDLength {
+		h.writeError(w, http.StatusBadRequest, "limit_exceeded", fmt.Sprintf("reference_id exceeds max length of %d", maxReferenceIDLength))
+		return ttsRequest{}, fmt.Errorf("reference id too long")
+	}
+
+	if payload.Format == "" {
+		payload.Format = defaultAudioFormat
+	}
+	if payload.Format != "wav" {
+		h.writeError(w, http.StatusBadRequest, "invalid_request", "unsupported audio format")
+		return ttsRequest{}, fmt.Errorf("unsupported format")
+	}
+
+	if payload.TopP != nil {
+		if *payload.TopP <= 0 || *payload.TopP > 1 {
+			h.writeError(w, http.StatusBadRequest, "invalid_request", "top_p must be in (0, 1]")
+			return ttsRequest{}, fmt.Errorf("invalid top_p")
+		}
+	}
+
+	if payload.Temperature != nil {
+		if *payload.Temperature < 0 || *payload.Temperature > 2 {
+			h.writeError(w, http.StatusBadRequest, "invalid_request", "temperature must be between 0 and 2")
+			return ttsRequest{}, fmt.Errorf("invalid temperature")
+		}
+	}
+
+	return payload, nil
+}
+
+func (h *TTSHandler) handleStreamError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, streaming.ErrAcquireTimeout):
+		h.writeError(w, http.StatusGatewayTimeout, "acquire_timeout", "concurrent request limit reached")
+	case errors.Is(err, context.DeadlineExceeded):
+		h.writeError(w, http.StatusGatewayTimeout, "timeout", "request timed out")
+	default:
+		var httpErr backend.HTTPError
+		if errors.As(err, &httpErr) {
+			h.writeError(w, http.StatusBadGateway, "backend_error", httpErr.Error())
+			return
+		}
+
+		h.writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+	}
+}
+
+func (h *TTSHandler) writeError(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"error": map[string]any{
+			"code":    code,
+			"message": message,
+		},
+	})
+}

--- a/internal/api/tts_handler_test.go
+++ b/internal/api/tts_handler_test.go
@@ -1,0 +1,163 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"fish-speech-go/internal/backend"
+	"fish-speech-go/internal/streaming"
+)
+
+type stubBackend struct {
+	stream func(context.Context, backend.TTSRequest) (*http.Response, error)
+}
+
+func (s *stubBackend) StreamTTS(ctx context.Context, req backend.TTSRequest) (*http.Response, error) {
+	return s.stream(ctx, req)
+}
+
+func TestTTSHandlerValidatesRequest(t *testing.T) {
+	handler := NewTTSHandler(streaming.NewChunker(streaming.ChunkerConfig{MaxConcurrent: 2}), &stubBackend{})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	resp, err := http.Post(server.URL, "application/json", bytes.NewBufferString(`{}`))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("failed to decode error payload: %v", err)
+	}
+
+	if payload.Error.Code != "invalid_request" {
+		t.Fatalf("unexpected error code: %s", payload.Error.Code)
+	}
+}
+
+func TestTTSHandlerStreamsSuccess(t *testing.T) {
+	backendCalled := make(chan backend.TTSRequest, 1)
+	handler := NewTTSHandler(streaming.NewChunker(streaming.ChunkerConfig{MaxConcurrent: 2}), &stubBackend{
+		stream: func(_ context.Context, req backend.TTSRequest) (*http.Response, error) {
+			backendCalled <- req
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"audio/wav"}},
+				Body:       io.NopCloser(strings.NewReader("audio-bytes")),
+			}, nil
+		},
+	})
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	resp, err := http.Post(server.URL, "application/json", bytes.NewBufferString(`{"text":"hello","format":"wav","streaming":true}`))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "audio/wav" {
+		t.Fatalf("unexpected content type: %s", ct)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read body: %v", err)
+	}
+	if string(body) != "audio-bytes" {
+		t.Fatalf("unexpected body: %s", string(body))
+	}
+
+	select {
+	case req := <-backendCalled:
+		if req.Text != "hello" || req.Format != "wav" || !req.Streaming {
+			t.Fatalf("unexpected backend request: %+v", req)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("backend was not called")
+	}
+}
+
+func TestTTSHandlerAcquireTimeout(t *testing.T) {
+	chunker := streaming.NewChunker(streaming.ChunkerConfig{MaxConcurrent: 1, AcquireTimeout: 50 * time.Millisecond})
+	release := make(chan struct{})
+	started := make(chan struct{})
+
+	backendStub := &stubBackend{stream: func(_ context.Context, _ backend.TTSRequest) (*http.Response, error) {
+		pr, pw := io.Pipe()
+		go func() {
+			close(started)
+			_, _ = pw.Write([]byte("chunk"))
+			<-release
+			pw.Close()
+		}()
+
+		return &http.Response{StatusCode: http.StatusOK, Body: pr}, nil
+	}}
+
+	handler := NewTTSHandler(chunker, backendStub)
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		resp, err := http.Post(server.URL, "application/json", bytes.NewBufferString(`{"text":"first","format":"wav"}`))
+		if err != nil {
+			t.Errorf("first request failed: %v", err)
+			return
+		}
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+
+	<-started
+
+	resp, err := http.Post(server.URL, "application/json", bytes.NewBufferString(`{"text":"second","format":"wav"}`))
+	if err != nil {
+		t.Fatalf("second request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusGatewayTimeout {
+		t.Fatalf("expected 504, got %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("failed to decode error payload: %v", err)
+	}
+	if payload.Error.Code != "acquire_timeout" {
+		t.Fatalf("unexpected error code: %s", payload.Error.Code)
+	}
+
+	close(release)
+	wg.Wait()
+}

--- a/internal/backend/client.go
+++ b/internal/backend/client.go
@@ -1,0 +1,183 @@
+package backend
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// TTSRequest represents the payload expected by the Python TTS backend.
+type TTSRequest struct {
+	Text        string   `msgpack:"text"`
+	ReferenceID string   `msgpack:"reference_id,omitempty"`
+	Streaming   bool     `msgpack:"streaming"`
+	Format      string   `msgpack:"format"`
+	TopP        *float64 `msgpack:"top_p,omitempty"`
+	Temperature *float64 `msgpack:"temperature,omitempty"`
+}
+
+// HTTPError surfaces non-successful responses from the backend.
+type HTTPError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e HTTPError) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("backend responded with status %d: %s", e.StatusCode, e.Message)
+	}
+	return fmt.Sprintf("backend responded with status %d", e.StatusCode)
+}
+
+// Client sends MessagePack encoded requests to the backend service.
+type Client struct {
+	baseURL    string
+	timeout    time.Duration
+	httpClient *http.Client
+}
+
+// NewClient constructs a backend client with the provided base URL. If httpClient is nil,
+// http.DefaultClient is used. When timeout is non-zero, requests are bounded by it.
+func NewClient(baseURL string, timeout time.Duration, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	return &Client{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		timeout:    timeout,
+		httpClient: httpClient,
+	}
+}
+
+// StreamTTS sends the request to the backend and returns the raw HTTP response for streaming.
+// The caller is responsible for closing the response body when the returned error is nil.
+func (c *Client) StreamTTS(ctx context.Context, payload TTSRequest) (*http.Response, error) {
+	encoded, err := encodeTTSRequest(payload)
+	if err != nil {
+		return nil, fmt.Errorf("encode msgpack: %w", err)
+	}
+
+	if c.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.timeout)
+		defer cancel()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/tts", bytes.NewReader(encoded))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/msgpack")
+	req.Header.Set("Accept", "application/octet-stream")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("perform request: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		message, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		resp.Body.Close()
+		return nil, HTTPError{StatusCode: resp.StatusCode, Message: string(message)}
+	}
+
+	return resp, nil
+}
+
+func encodeTTSRequest(payload TTSRequest) ([]byte, error) {
+	count := 3 // text, streaming, format are always present
+	if payload.ReferenceID != "" {
+		count++
+	}
+	if payload.TopP != nil {
+		count++
+	}
+	if payload.Temperature != nil {
+		count++
+	}
+
+	buf := &bytes.Buffer{}
+	if err := writeMapHeader(buf, count); err != nil {
+		return nil, err
+	}
+
+	writeString(buf, "text")
+	writeString(buf, payload.Text)
+
+	if payload.ReferenceID != "" {
+		writeString(buf, "reference_id")
+		writeString(buf, payload.ReferenceID)
+	}
+
+	writeString(buf, "streaming")
+	writeBool(buf, payload.Streaming)
+
+	writeString(buf, "format")
+	writeString(buf, payload.Format)
+
+	if payload.TopP != nil {
+		writeString(buf, "top_p")
+		writeFloat64(buf, *payload.TopP)
+	}
+
+	if payload.Temperature != nil {
+		writeString(buf, "temperature")
+		writeFloat64(buf, *payload.Temperature)
+	}
+
+	return buf.Bytes(), nil
+}
+
+func writeMapHeader(buf *bytes.Buffer, size int) error {
+	switch {
+	case size < 0:
+		return errors.New("negative map size")
+	case size <= 15:
+		buf.WriteByte(0x80 | byte(size))
+	case size <= 0xffff:
+		buf.WriteByte(0xde)
+		_ = binary.Write(buf, binary.BigEndian, uint16(size))
+	default:
+		return fmt.Errorf("map too large: %d", size)
+	}
+	return nil
+}
+
+func writeString(buf *bytes.Buffer, value string) {
+	length := len(value)
+	switch {
+	case length <= 31:
+		buf.WriteByte(0xa0 | byte(length))
+	case length <= 0xff:
+		buf.WriteByte(0xd9)
+		buf.WriteByte(byte(length))
+	case length <= 0xffff:
+		buf.WriteByte(0xda)
+		_ = binary.Write(buf, binary.BigEndian, uint16(length))
+	default:
+		buf.WriteByte(0xdb)
+		_ = binary.Write(buf, binary.BigEndian, uint32(length))
+	}
+	buf.WriteString(value)
+}
+
+func writeBool(buf *bytes.Buffer, value bool) {
+	if value {
+		buf.WriteByte(0xc3)
+		return
+	}
+	buf.WriteByte(0xc2)
+}
+
+func writeFloat64(buf *bytes.Buffer, value float64) {
+	buf.WriteByte(0xcb)
+	_ = binary.Write(buf, binary.BigEndian, value)
+}

--- a/internal/backend/client_test.go
+++ b/internal/backend/client_test.go
@@ -1,0 +1,95 @@
+package backend
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestClientStreamTTSSuccess(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Content-Type") != "application/msgpack" {
+			t.Fatalf("unexpected content type: %s", r.Header.Get("Content-Type"))
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read body: %v", err)
+		}
+
+		expected := []byte{
+			0x83,
+			0xa4, 't', 'e', 'x', 't',
+			0xa5, 'h', 'e', 'l', 'l', 'o',
+			0xa9, 's', 't', 'r', 'e', 'a', 'm', 'i', 'n', 'g', 0xc2,
+			0xa6, 'f', 'o', 'r', 'm', 'a', 't',
+			0xa3, 'w', 'a', 'v',
+		}
+
+		if !bytes.Equal(body, expected) {
+			t.Fatalf("unexpected msgpack payload: %v", body)
+		}
+
+		w.Header().Set("Content-Type", "audio/wav")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("audio"))
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	t.Cleanup(server.Close)
+
+	client := NewClient(server.URL, 5*time.Second, server.Client())
+	resp, err := client.StreamTTS(context.Background(), TTSRequest{Text: "hello", Format: "wav"})
+	if err != nil {
+		t.Fatalf("StreamTTS returned error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response: %v", err)
+	}
+	if string(body) != "audio" {
+		t.Fatalf("unexpected body: %s", string(body))
+	}
+}
+
+func TestClientStreamTTSErrorStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(server.URL, 0, server.Client())
+	_, err := client.StreamTTS(context.Background(), TTSRequest{Text: "hello", Format: "wav"})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	var httpErr HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected HTTPError, got %T", err)
+	}
+	if httpErr.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("unexpected status: %d", httpErr.StatusCode)
+	}
+}
+
+func TestClientStreamTTSTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(server.URL, 50*time.Millisecond, server.Client())
+	_, err := client.StreamTTS(context.Background(), TTSRequest{Text: "hello", Format: "wav"})
+	if err == nil {
+		t.Fatalf("expected timeout error, got nil")
+	}
+}

--- a/internal/streaming/chunker.go
+++ b/internal/streaming/chunker.go
@@ -74,3 +74,15 @@ func (c *Chunker) releaseFn() func() {
 		}
 	}
 }
+
+// Stream executes the provided function while holding a slot. The slot is released when the
+// function returns, allowing callers to guard streaming workloads without manual bookkeeping.
+func (c *Chunker) Stream(ctx context.Context, streamFn func(context.Context) error) error {
+	release, err := c.Acquire(ctx)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	return streamFn(ctx)
+}


### PR DESCRIPTION
## Summary
- add a TTS HTTP handler that validates requests, enforces limits, and streams backend audio responses
- implement a MessagePack backend client with timeout handling and structured backend error surfacing
- extend the streaming chunker with a Stream helper and cover the new paths with tests

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926a1218628832cbd8458ba2d8469fa)