### PR TITLE
Add schema validation layer

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,7 @@
+module github.com/fish-speech-go/fish-speech-go
+
+go 1.21
+
+require github.com/vmihailenco/msgpack/v5 v5.4.1
+
+require github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
+github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go/internal/schema/common.go
+++ b/go/internal/schema/common.go
@@ -1,0 +1,11 @@
+package schema
+
+// ErrorResponse represents a standard error payload.
+type ErrorResponse struct {
+	Detail string `json:"detail" msgpack:"detail"`
+}
+
+// HealthResponse represents the health check response payload.
+type HealthResponse struct {
+	Status string `json:"status" msgpack:"status"`
+}

--- a/go/internal/schema/references.go
+++ b/go/internal/schema/references.go
@@ -1,0 +1,29 @@
+package schema
+
+// AddReferenceRequest represents a request to add a new voice reference.
+type AddReferenceRequest struct {
+	ID    string `json:"id" msgpack:"id"`
+	Audio []byte `json:"audio" msgpack:"audio"`
+	Text  string `json:"text" msgpack:"text"`
+}
+
+// AddReferenceResponse represents the response after adding a voice reference.
+type AddReferenceResponse struct {
+	Success     bool   `json:"success" msgpack:"success"`
+	Message     string `json:"message" msgpack:"message"`
+	ReferenceID string `json:"reference_id" msgpack:"reference_id"`
+}
+
+// ListReferencesResponse represents the response for listing voice references.
+type ListReferencesResponse struct {
+	Success      bool     `json:"success" msgpack:"success"`
+	ReferenceIDs []string `json:"reference_ids" msgpack:"reference_ids"`
+	Message      string   `json:"message" msgpack:"message"`
+}
+
+// DeleteReferenceResponse represents the response when deleting a voice reference.
+type DeleteReferenceResponse struct {
+	Success     bool   `json:"success" msgpack:"success"`
+	Message     string `json:"message" msgpack:"message"`
+	ReferenceID string `json:"reference_id" msgpack:"reference_id"`
+}

--- a/go/internal/schema/schema_test.go
+++ b/go/internal/schema/schema_test.go
@@ -1,0 +1,188 @@
+package schema
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+func TestServeTTSRequestDefaults(t *testing.T) {
+	req := &ServeTTSRequest{Text: "hello"}
+
+	if err := req.Validate(0); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if req.ChunkLength != 200 {
+		t.Fatalf("expected default chunk_length 200, got %d", req.ChunkLength)
+	}
+	if req.Format != "wav" {
+		t.Fatalf("expected default format wav, got %s", req.Format)
+	}
+	if req.MaxNewTokens != 1024 {
+		t.Fatalf("expected default max_new_tokens 1024, got %d", req.MaxNewTokens)
+	}
+	if req.TopP != 0.8 {
+		t.Fatalf("expected default top_p 0.8, got %f", req.TopP)
+	}
+	if req.RepetitionPenalty != 1.1 {
+		t.Fatalf("expected default repetition_penalty 1.1, got %f", req.RepetitionPenalty)
+	}
+	if req.Temperature != 0.8 {
+		t.Fatalf("expected default temperature 0.8, got %f", req.Temperature)
+	}
+	if req.UseMemoryCache != "off" {
+		t.Fatalf("expected default use_memory_cache off, got %s", req.UseMemoryCache)
+	}
+	if !req.Normalize {
+		t.Fatalf("expected default normalize true")
+	}
+	if req.Streaming {
+		t.Fatalf("expected default streaming false")
+	}
+	if req.References == nil {
+		t.Fatalf("expected references to default to empty slice")
+	}
+}
+
+func TestServeTTSRequestValidationErrors(t *testing.T) {
+	tests := []struct {
+		name          string
+		req           ServeTTSRequest
+		maxTextLength int
+		expectedError string
+	}{
+		{
+			name:          "chunk length below range",
+			req:           ServeTTSRequest{Text: "hi", ChunkLength: 50},
+			expectedError: "chunk_length must be between 100 and 300",
+		},
+		{
+			name:          "top_p below range",
+			req:           ServeTTSRequest{Text: "hi", TopP: 0.05},
+			expectedError: "top_p must be between 0. 1 and 1. 0",
+		},
+		{
+			name:          "temperature above range",
+			req:           ServeTTSRequest{Text: "hi", Temperature: 1.5},
+			expectedError: "temperature must be between 0.1 and 1. 0",
+		},
+		{
+			name:          "repetition penalty below range",
+			req:           ServeTTSRequest{Text: "hi", RepetitionPenalty: 0.5},
+			expectedError: "repetition_penalty must be between 0. 9 and 2. 0",
+		},
+		{
+			name:          "streaming with non wav format",
+			req:           ServeTTSRequest{Text: "hi", Streaming: true, Format: "mp3"},
+			expectedError: "Streaming only supports WAV format",
+		},
+		{
+			name:          "text too long",
+			req:           ServeTTSRequest{Text: "hello world"},
+			maxTextLength: 5,
+			expectedError: "Text is too long, max length is 5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.req.Validate(tt.maxTextLength)
+			if err == nil {
+				t.Fatalf("expected error but got nil")
+			}
+			if err.Error() != tt.expectedError {
+				t.Fatalf("expected error %q, got %q", tt.expectedError, err.Error())
+			}
+		})
+	}
+}
+
+func TestServeTTSRequestJSONTags(t *testing.T) {
+	referenceID := "ref-1"
+	seed := 42
+	req := ServeTTSRequest{
+		Text:              "hello",
+		ChunkLength:       150,
+		Format:            "mp3",
+		MaxNewTokens:      500,
+		TopP:              0.9,
+		RepetitionPenalty: 1.0,
+		Temperature:       0.6,
+		References: []ServeReferenceAudio{{
+			Audio: []byte{0x01, 0x02},
+			Text:  "ref text",
+		}},
+		ReferenceID:    &referenceID,
+		Seed:           &seed,
+		UseMemoryCache: "on",
+		Normalize:      true,
+		Streaming:      true,
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal to json: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal json: %v", err)
+	}
+
+	expectedKeys := []string{
+		"text", "chunk_length", "format", "max_new_tokens", "top_p", "repetition_penalty",
+		"temperature", "references", "reference_id", "seed", "use_memory_cache", "normalize", "streaming",
+	}
+
+	for _, key := range expectedKeys {
+		if _, ok := decoded[key]; !ok {
+			t.Fatalf("expected key %s in json output", key)
+		}
+	}
+}
+
+func TestServeTTSRequestMsgpackTags(t *testing.T) {
+	referenceID := "ref-1"
+	seed := 42
+	req := ServeTTSRequest{
+		Text:              "hello",
+		ChunkLength:       150,
+		Format:            "mp3",
+		MaxNewTokens:      500,
+		TopP:              0.9,
+		RepetitionPenalty: 1.0,
+		Temperature:       0.6,
+		References: []ServeReferenceAudio{{
+			Audio: []byte{0x01, 0x02},
+			Text:  "ref text",
+		}},
+		ReferenceID:    &referenceID,
+		Seed:           &seed,
+		UseMemoryCache: "on",
+		Normalize:      true,
+		Streaming:      true,
+	}
+
+	data, err := msgpack.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal to msgpack: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := msgpack.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal msgpack: %v", err)
+	}
+
+	expectedKeys := []string{
+		"text", "chunk_length", "format", "max_new_tokens", "top_p", "repetition_penalty",
+		"temperature", "references", "reference_id", "seed", "use_memory_cache", "normalize", "streaming",
+	}
+
+	for _, key := range expectedKeys {
+		if _, ok := decoded[key]; !ok {
+			t.Fatalf("expected key %s in msgpack output", key)
+		}
+	}
+}

--- a/go/internal/schema/tts.go
+++ b/go/internal/schema/tts.go
@@ -1,0 +1,107 @@
+package schema
+
+import "fmt"
+
+const (
+	defaultChunkLength       = 200
+	defaultFormat            = "wav"
+	defaultMaxNewTokens      = 1024
+	defaultTopP              = 0.8
+	defaultRepetitionPenalty = 1.1
+	defaultTemperature       = 0.8
+	defaultUseMemoryCache    = "off"
+	defaultNormalize         = true
+)
+
+// ServeReferenceAudio represents an inline reference audio payload.
+type ServeReferenceAudio struct {
+	Audio []byte `json:"audio" msgpack:"audio"`
+	Text  string `json:"text" msgpack:"text"`
+}
+
+// ServeTTSRequest represents the upstream ServeTTSRequest schema.
+type ServeTTSRequest struct {
+	Text string `json:"text" msgpack:"text"`
+
+	ChunkLength       int     `json:"chunk_length" msgpack:"chunk_length"`
+	Format            string  `json:"format" msgpack:"format"`
+	MaxNewTokens      int     `json:"max_new_tokens" msgpack:"max_new_tokens"`
+	TopP              float64 `json:"top_p" msgpack:"top_p"`
+	RepetitionPenalty float64 `json:"repetition_penalty" msgpack:"repetition_penalty"`
+	Temperature       float64 `json:"temperature" msgpack:"temperature"`
+
+	References  []ServeReferenceAudio `json:"references" msgpack:"references"`
+	ReferenceID *string               `json:"reference_id,omitempty" msgpack:"reference_id,omitempty"`
+
+	Seed           *int   `json:"seed,omitempty" msgpack:"seed,omitempty"`
+	UseMemoryCache string `json:"use_memory_cache" msgpack:"use_memory_cache"`
+	Normalize      bool   `json:"normalize" msgpack:"normalize"`
+	Streaming      bool   `json:"streaming" msgpack:"streaming"`
+}
+
+// Validate applies default values and validates the request against upstream rules.
+func (r *ServeTTSRequest) Validate(maxTextLength int) error {
+	r.applyDefaults()
+
+	if maxTextLength > 0 && len(r.Text) > maxTextLength {
+		return fmt.Errorf("Text is too long, max length is %d", maxTextLength)
+	}
+
+	if r.ChunkLength < 100 || r.ChunkLength > 300 {
+		return fmt.Errorf("chunk_length must be between 100 and 300")
+	}
+
+	if r.TopP < 0.1 || r.TopP > 1.0 {
+		return fmt.Errorf("top_p must be between 0. 1 and 1. 0")
+	}
+
+	if r.Temperature < 0.1 || r.Temperature > 1.0 {
+		return fmt.Errorf("temperature must be between 0.1 and 1. 0")
+	}
+
+	if r.RepetitionPenalty < 0.9 || r.RepetitionPenalty > 2.0 {
+		return fmt.Errorf("repetition_penalty must be between 0. 9 and 2. 0")
+	}
+
+	if r.Streaming && r.Format != "wav" {
+		return fmt.Errorf("Streaming only supports WAV format")
+	}
+
+	return nil
+}
+
+func (r *ServeTTSRequest) applyDefaults() {
+	if r.ChunkLength == 0 {
+		r.ChunkLength = defaultChunkLength
+	}
+
+	if r.Format == "" {
+		r.Format = defaultFormat
+	}
+
+	if r.MaxNewTokens == 0 {
+		r.MaxNewTokens = defaultMaxNewTokens
+	}
+
+	if r.TopP == 0 {
+		r.TopP = defaultTopP
+	}
+
+	if r.RepetitionPenalty == 0 {
+		r.RepetitionPenalty = defaultRepetitionPenalty
+	}
+
+	if r.Temperature == 0 {
+		r.Temperature = defaultTemperature
+	}
+
+	if r.References == nil {
+		r.References = []ServeReferenceAudio{}
+	}
+
+	if r.UseMemoryCache == "" {
+		r.UseMemoryCache = defaultUseMemoryCache
+	}
+
+	r.Normalize = r.Normalize || defaultNormalize
+}

--- a/go/internal/schema/vqgan.go
+++ b/go/internal/schema/vqgan.go
@@ -1,0 +1,21 @@
+package schema
+
+// ServeVQGANEncodeRequest represents a request to encode audio with VQGAN.
+type ServeVQGANEncodeRequest struct {
+	Audios [][]byte `json:"audios" msgpack:"audios"`
+}
+
+// ServeVQGANEncodeResponse represents the encoded token response from VQGAN.
+type ServeVQGANEncodeResponse struct {
+	Tokens [][][]int `json:"tokens" msgpack:"tokens"`
+}
+
+// ServeVQGANDecodeRequest represents a request to decode tokens with VQGAN.
+type ServeVQGANDecodeRequest struct {
+	Tokens [][][]int `json:"tokens" msgpack:"tokens"`
+}
+
+// ServeVQGANDecodeResponse represents decoded audio payloads from VQGAN.
+type ServeVQGANDecodeResponse struct {
+	Audios [][]byte `json:"audios" msgpack:"audios"`
+}


### PR DESCRIPTION
## Summary
- add Go schema package covering TTS, VQGAN, reference, health, and error payloads with JSON/MessagePack tags
- implement ServeTTSRequest defaults and upstream-compatible validation error messages
- introduce unit tests for defaults, validation behavior, and marshaling plus initialize Go module with msgpack dependency

## Testing
- GOPROXY=https://proxy.golang.org,direct go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926ba98bd3c832ca2fe1060fb93cd71)